### PR TITLE
`get_symbols` function provided.

### DIFF
--- a/src/Search_Symbol.jl
+++ b/src/Search_Symbol.jl
@@ -1,1 +1,44 @@
-# Possibly Make it possible to search for tickers.
+# Supported markets
+const MARKETS = ["AMEX", "NASDAQ", "NYSE"]
+
+"""
+    get_symbols(market::String)
+
+Fetch all the symbols from a given `market`.
+
+# Arguments
+- `market::String`: The market to fetch the symbols from.
+Currently supported markets are:
+  - `AMEX`
+  - `NASDAQ`
+  - `NYSE`
+
+# Returns
+- `Vector{String}`: A vector of strings containing the symbols.
+
+# Example
+```julia
+julia> get_symbols("NYSE")
+3127-element Vector{String}:
+ "A"
+ "AA"
+ "AAC"
+ "AAN"
+ ⋮
+ "ZTR"
+ "ZTS"
+ "ZUO"
+ "ZYME"
+"""
+function get_symbols(market::String)::Vector{String}
+  uppercase(market) in MARKETS || throw(ArgumentError("Invalid market. Supported markets \
+  are $(MARKETS)"))
+  url = "https://dumbstockapi.com/stock?format=tickers-only&exchange=$market"
+  response = HTTP.request("GET", url)
+  Symbols_string::String = String(response.body)
+  splitted::Vector{String} = split(Symbols_string, ",")
+  pured::Vector{String} = replace.(splitted, r"\"" => "")
+  pured[1] = replace(pured[1], r"\[" => "")
+  pured[lastindex(pured)] = replace(pured[lastindex(pured)], r"\]" => "")
+  return pured
+end;

--- a/src/YFinance.jl
+++ b/src/YFinance.jl
@@ -12,7 +12,8 @@ module YFinance
     export get_calendar_events,get_earnings_estimates,get_eps,get_insider_holders,get_insider_transactions
     export get_institutional_ownership,get_major_holders_breakdown,get_recommendation_trend
     export get_summary_detail,get_sector_industry,get_upgrade_downgrade_history
-    
+    export get_symbols
+
     # Load Order
     include("Proxy_Auth.jl");
     include("Validity.jl");

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ using Test
 
         ta = get_prices("ADANIENT.NS",startdt =Dates.today()-Year(10) , enddt = Dates.today())
         @test length(ta["timestamp"]) > 100
-        
+
         ta = get_Fundamental("AAPL","income_statement","annual",Dates.today() - Year(5),Dates.today())
         @test in("InterestExpense",keys(ta))
         @test length(ta["InterestExpense"]) > 3
@@ -25,31 +25,42 @@ using Test
 
         ta = get_ESG("AAPL")
         @test in("score",keys(ta))
-        @test length(ta["score"]["timestamp"]) > 0     
+        @test length(ta["score"]["timestamp"]) > 0
 
         ta = get_quoteSummary("AAPL")
         @test in(:price,keys(ta))
-        
+
         @test haskey(get_calendar_events(ta),"earnings_dates")
-        
+
         @test haskey(get_earnings_estimates(ta),"estimate")
-        
+
         @test haskey(get_eps(ta),"estimate")
-        
+
         @test haskey(get_insider_holders(ta),"name")
-        
+
         @test haskey(get_insider_transactions(ta),"filerName")
-        
+
         @test haskey(get_institutional_ownership(ta),"organization")
-        
+
         @test haskey(get_major_holders_breakdown(ta),"institutionsCount")
-        
+
         @test haskey(get_recommendation_trend(ta),"strongbuy")
-        
+
         @test haskey(get_summary_detail(ta),"tradeable")
-        
+
         @test haskey(get_sector_industry(ta),"sector")
-        
+
         @test haskey(get_upgrade_downgrade_history(ta),"firm")
 
+        @testset "Search_Symbol" begin
+            # Test case insensitivity
+            @test length(get_symbols("nySE")) == length(get_symbols("NYSE"))
+
+            # Test if the market is supported
+            @test_throws ArgumentError get_symbols("wrong")
+
+            @test isa(get_symbols("NASDAQ"), Vector{String})
+
+            @test length(get_symbols("AMEX")) > 100
+        end
 end


### PR DESCRIPTION
This PR follows this issue https://github.com/eohne/YFinance.jl/issues/8
I provided a function that fetches symbols from [this API](https://dumbstockapi.com/). I tried to avoid bringing new dependencies and Just utilized the `HTTP.jl` package for it, which has been available as a dependency.  However, the currently supported markets are "NASDAQ", "AMAX", and "NYSE". Although this is better than nothing, further markets can be added in the future.  